### PR TITLE
feat(scan): expose full language list, add dir input, align with Source Code API Discovery docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   - [Test Application Action](#test-application-action)
     - [Usage](#usage-2)
     - [Output](#output-2)
-  - [Scan Repository](#scan-repository)
+  - [Source Code API Discovery](#source-code-api-discovery)
     - [Usage](#usage-3)
     - [Output](#output-3)
   - [DAST Scanner](#dast-scanner)
@@ -155,11 +155,11 @@ outputs:
     description: '# of skipped test cases'
 ```
 
-## Scan Repository
+## Source Code API Discovery
 
-This action scans a repository and import results to your [Levo-app](https://app.levo.ai) organization dashboard.
+This action statically analyzes application source code to discover REST API endpoints and imports them into your [Levo.ai](https://app.levo.ai) organization as an OpenAPI 3.0.1 specification. The application is never executed, no traffic is captured, and no staging environment is required — source code never leaves the runner; only the generated specification is uploaded.
 
-This action will require you to have a Levo account and provide a Authorization Key and Organization ID.
+Requires a Levo account (Authorization Key + Organization ID) and Docker on the runner.
 
 ### Usage
 
@@ -167,23 +167,29 @@ This action will require you to have a Levo account and provide a Authorization 
 ```yaml
 - uses: levoai/actions/scan@v2.1.2
   with:
-    # Authorization key required to execute the Levo CLI. Please refer to https://app.levo.ai/settings/keys to get your authorization key.
+    # Levo CLI authorization key. Get yours at https://app.levo.ai/settings/keys
     authorization-key: ''
 
-    # The ID of your organization in Levo dashboard. Please refer to https://app.levo.ai/settings/organization to get your organization id.
+    # Your Levo organization ID. Find it at https://app.levo.ai/settings/organization
     organization-id: ''
-    
-    # The name of the application to be created in Levo.
+
+    # Application name to display on the Levo dashboard. The application record is created automatically on first scan.
     app-name: ''
 
-    # [Optional] The name of the environment in which app must be created in Levo.
+    # Programming language of the repository. Supported: java, jar, javascript, typescript, python, c, cpp, csharp, php, ruby, apk
+    language: ''
+
+    # [Optional] Relative subdirectory (e.g. ./path/to/sub-directory) to scan. Use "." to scan the repository root.
+    dir: '.'
+
+    # [Optional] Target environment. Default: staging.
     env-name: ''
 ```
 <!-- end usage -->
 
 ### Output
 
-This action will create an application in Levo[https://app.levo.ai] and import the results of the scan.
+The action imports discovered endpoints into the Levo dashboard under the application named by `app-name`, in the environment named by `env-name`.
 
 ## DAST Scanner
 

--- a/scan/action.yaml
+++ b/scan/action.yaml
@@ -1,18 +1,22 @@
-name: "Levo Action to scan repository for API endpoints"
-description: "Scan source code for API endpoints using the Levo Code Scanner and upload OpenAPI specs to the Levo dashboard"
+name: "Levo Source Code API Discovery"
+description: "Statically analyze application source code to discover REST API endpoints and import them into Levo.ai as an OpenAPI specification."
 inputs:
   authorization-key:
-    description: 'Authorization key for CLI to run. Get it from https://app.levo.ai/settings/keys'
+    description: 'Levo CLI authorization key. Get yours at https://app.levo.ai/settings/keys'
     required: true
   organization-id:
-    description: 'Levo Organization ID'
+    description: 'Levo organization ID. Find it at https://app.levo.ai/settings/organization'
     required: true
   app-name:
-    description: 'Application name'
+    description: 'Application name to display on the Levo dashboard. The application record is created automatically on first scan.'
     required: true
   language:
-    description: 'Programming language of the repo (java, python, javascript, typescript, c, cpp, php, ruby)'
+    description: 'Programming language of the repository. Supported: java, jar, javascript, typescript, python, c, cpp, csharp, php, ruby, apk'
     required: true
+  dir:
+    description: 'Relative subdirectory (e.g. ./path/to/sub-directory) to scan. Use "." to scan the repository root.'
+    required: false
+    default: '.'
   env-name:
     description: 'Environment name'
     required: false
@@ -30,7 +34,7 @@ runs:
   steps:
     - id: run-scan-repo
       run: |
-        echo "Scanning '${{ inputs.app-name }}' (language: ${{ inputs.language }}, env: ${{ inputs.env-name }})"
+        echo "Scanning '${{ inputs.app-name }}' (language: ${{ inputs.language }}, dir: ${{ inputs.dir }}, env: ${{ inputs.env-name }})"
         echo "Using image: ${{ inputs.scanner-docker-image }}"
 
         set +e
@@ -42,6 +46,7 @@ runs:
           ${{ inputs.scanner-docker-image }} \
           --app-name "${{ inputs.app-name }}" \
           --language ${{ inputs.language }} \
+          --dir "${{ inputs.dir }}" \
           --env-name ${{ inputs.env-name }} \
           -k ${{ inputs.authorization-key }} \
           -o ${{ inputs.organization-id }} 2>&1)


### PR DESCRIPTION
## Summary

Aligns the `scan` action with the underlying Levo Code Scanner CLI and the new [Source Code API Discovery docs (levoai/docs#427)](https://github.com/levoai/docs/pull/427).

- **Language list corrected.** The action previously advertised only 8 languages (`java, python, javascript, typescript, c, cpp, php, ruby`), but the CLI (`levo-code-scanner`) accepts: `java, jar, javascript, typescript, python, c, cpp, csharp, php, ruby, apk`. Public docs that claimed only two languages were supported are now consistent with what the CLI has always accepted.
- **`dir` input added.** New optional input (default `.`) maps straight to the CLI's `--dir`, so users can scan a subdirectory of the repo instead of the whole root.
- **Renamed + reworded** to match the docs PR: `name` is now `Levo Source Code API Discovery`, `description` and per-input descriptions mirror the docs' phrasing.
- **`csharp`, not `dotnet`**, is surfaced. The Roslyn extractor (`DotnetOpenApiExtractor/Program.cs`) only parses `.cs` files via `Microsoft.CodeAnalysis.CSharp` — no F# or VB.NET — so exposing the `dotnet` alias in user-facing docs would be misleading. The CLI still accepts `dotnet` as an alias for backward compat.

## Test plan

- [ ] Run the action on a Java repo (existing behaviour) — scan still succeeds and imports to the dashboard.
- [ ] Run on a C# / ASP.NET Core repo with `language: csharp` — verify endpoints are imported via the Roslyn extractor.
- [ ] Run with `dir: ./services/api` on a monorepo — verify only that subdirectory is scanned.
- [ ] Run with an unsupported `language` value — CLI surfaces a clear error and the step fails.

## Follow-ups (not in this PR)

- [levoai/docs#427](https://github.com/levoai/docs/pull/427)'s Action Inputs table is missing `language` (required) and `dir` (optional) rows, and the Supported Languages table omits C# — worth a small follow-up commit on the docs PR to match.
- Ruby runtime version drift: CLI README says Ruby 4.0.x, docs PR says Ruby 3.4.7. Needs reconciliation with whoever owns the scanner's runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)