### PR TITLE
CU-86ba40nzj feat: Release notes workflow checks and auto-fill the PRs

### DIFF
--- a/release-note-validator/action.yaml
+++ b/release-note-validator/action.yaml
@@ -1,0 +1,39 @@
+name: "Release Note Validator"
+description: |
+  Enforce the `release-note:` convention on pull requests.
+  Auto-fills `release-note: NONE` for cleanup-style PRs (chore/refactor/test/docs/ci/build prefixes),
+  then verifies that the PR description contains a line starting with `release-note:`.
+
+  At release time, a separate aggregator reads these lines from every merged PR between
+  two release tags to generate RELEASE_NOTES.md (all entries) and UPGRADE_NOTES.md (BREAKING entries).
+
+inputs:
+  pr-number:
+    description: Pull request number to validate.
+    required: true
+  pr-title:
+    description: "Pull request title. Used to decide whether to auto-fill `release-note: NONE`."
+    required: true
+  github-token:
+    description: GitHub token used to read and patch PR data. Caller's GITHUB_TOKEN works.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Auto-add release-note: for cleanup PRs"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUM: ${{ inputs.pr-number }}
+        PR_TITLE: ${{ inputs.pr-title }}
+      run: ${{ github.action_path }}/scripts/autofill.sh
+
+    - name: "Verify release-note: line exists"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR_NUM: ${{ inputs.pr-number }}
+      run: ${{ github.action_path }}/scripts/check.sh

--- a/release-note-validator/scripts/autofill.sh
+++ b/release-note-validator/scripts/autofill.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 body=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.body // ""')
 
 # Skip if release-note: already present anywhere in the body (allow leading whitespace)
-if printf '%s' "$body" | grep -qE '^[[:space:]]*release-note:'; then
+if grep -qE '^[[:space:]]*release-note:' <<< "$body"; then
   echo "release-note: already present in PR body, skipping autofill"
   exit 0
 fi
@@ -24,7 +24,7 @@ fi
 # Skip if title does not match cleanup prefixes.
 # Matches: chore:, refactor:, test:, docs:, ci:, build:
 # Also matches scoped variants like chore(deps):, refactor(iam):
-if ! printf '%s' "$PR_TITLE" | grep -qE '^(chore|refactor|test|docs|ci|build)(\([^)]*\))?:'; then
+if ! grep -qE '^(chore|refactor|test|docs|ci|build)(\([^)]*\))?:' <<< "$PR_TITLE"; then
   echo "Title prefix not in autofill list, skipping"
   exit 0
 fi

--- a/release-note-validator/scripts/autofill.sh
+++ b/release-note-validator/scripts/autofill.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# autofill.sh
+#
+# Prepends `release-note: NONE` to a PR body when the PR title starts with
+# a cleanup-style prefix (chore, refactor, test, docs, ci, build).
+#
+# Behaviour:
+#   - If PR body already contains a `release-note:` line → do nothing (no overwrite)
+#   - If PR title does NOT start with a cleanup prefix → do nothing
+#   - Otherwise → prepend `release-note: NONE` as the first line of the PR body
+
+set -euo pipefail
+
+# Fetch current PR body
+body=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.body // ""')
+
+# Skip if release-note: already present anywhere in the body (allow leading whitespace)
+if printf '%s' "$body" | grep -qE '^[[:space:]]*release-note:'; then
+  echo "release-note: already present in PR body, skipping autofill"
+  exit 0
+fi
+
+# Skip if title does not match cleanup prefixes.
+# Matches: chore:, refactor:, test:, docs:, ci:, build:
+# Also matches scoped variants like chore(deps):, refactor(iam):
+if ! printf '%s' "$PR_TITLE" | grep -qE '^(chore|refactor|test|docs|ci|build)(\([^)]*\))?:'; then
+  echo "Title prefix not in autofill list, skipping"
+  exit 0
+fi
+
+# Prepend release-note: NONE as the FIRST line of the body
+new_body=$(printf 'release-note: NONE\n\n%s' "$body")
+
+gh api "repos/${REPO}/pulls/${PR_NUM}" \
+  --method PATCH \
+  --field body="$new_body" > /dev/null
+
+echo "✓ Auto-added 'release-note: NONE' to PR #${PR_NUM}"

--- a/release-note-validator/scripts/check.sh
+++ b/release-note-validator/scripts/check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# check.sh
+#
+# Verifies that a PR body contains a line starting with `release-note:`.
+# Fails the calling job (exit 1) if the line is missing.
+#
+# Accepted forms (validated as "line exists" only — content is free-form):
+#   release-note: NONE
+#   release-note: <one-line customer-facing summary>
+#   release-note: BREAKING: <summary describing the upgrade procedure>
+
+set -euo pipefail
+
+# Fetch PR body
+body=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.body // ""')
+
+# release-note: line must exist (allow leading whitespace for indented Markdown)
+if ! printf '%s' "$body" | grep -qE '^[[:space:]]*release-note:'; then
+  echo "::error::Missing 'release-note:' block in PR description."
+  echo "::notice::Add ONE of the following lines to your PR description:"
+  echo "::notice::  release-note: NONE"
+  echo "::notice::  release-note: <one-line customer-facing summary>"
+  echo "::notice::  release-note: BREAKING: <summary + upgrade procedure>"
+  exit 1
+fi
+
+echo "✓ release-note: line found"

--- a/release-note-validator/scripts/check.sh
+++ b/release-note-validator/scripts/check.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 body=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.body // ""')
 
 # release-note: line must exist (allow leading whitespace for indented Markdown)
-if ! printf '%s' "$body" | grep -qE '^[[:space:]]*release-note:'; then
+if ! grep -qE '^[[:space:]]*release-note:' <<< "$body"; then
   echo "::error::Missing 'release-note:' block in PR description."
   echo "::notice::Add ONE of the following lines to your PR description:"
   echo "::notice::  release-note: NONE"


### PR DESCRIPTION
## Summary

Adds a new composite action `release-note-validator` that enforces the
release-note convention on pull requests across Levo's component repos.

The action runs as a single step in a caller workflow and does two
things in order:
1. **Autofill** — if PR title starts with a cleanup prefix
   (`chore:`, `refactor:`, `test:`, `docs:`, `ci:`, `build:`), prepend
   `release-note: NONE` to the PR description automatically.
2. **Check** — verify the PR description contains a line starting with
   `release-note:`. Fail the calling job if missing.

At release time (separate work in platform-infrastructure), a Python
aggregator reads these lines from every PR merged between two release
tags to generate `RELEASE_NOTES.md` and `UPGRADE_NOTES.md` for the
customer release zip.

Part of the v1 release-notes automation proposed in:
[`release-engineering.md`](https://github.com/levoai/platform-infrastructure/pull/698)

## Files added

```
release-note-validator/
├── action.yaml           ← composite action definition
└── scripts/
    ├── autofill.sh       ← extracted bash, locally testable
    └── check.sh          ← extracted bash, locally testable
```

## Usage from a component repo

```yaml
# In <component-repo>/.github/workflows/on-prem-release-note.yml
on:
  pull_request:
    types: [opened, edited, synchronize, reopened, ready_for_review]

permissions:
  pull-requests: write   # autofill needs to PATCH PR body

jobs:
  validate:
    runs-on: ${{ fromJSON(vars.PI_RUNNER || '"ubuntu-latest"') }}
    steps:
      - uses: levoai/actions/release-note-validator@main
        with:
          pr-number: ${{ github.event.pull_request.number }}
          pr-title:  ${{ github.event.pull_request.title }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
```

## Local testing

Bash scripts run standalone — no GitHub Actions needed:

```bash
cd release-note-validator/scripts

# Test autofill
GH_TOKEN=$(gh auth token) \
REPO=levoai/platform-services \
PR_NUM=1234 \
PR_TITLE="chore: test autofill" \
bash autofill.sh

# Test check
GH_TOKEN=$(gh auth token) \
REPO=levoai/platform-services \
PR_NUM=1234 \
bash check.sh
```