### PR TITLE
CU-86ba9pz96 Skip all workflows on draft PRs

### DIFF
--- a/.github/workflows/arc-test-action.yaml
+++ b/.github/workflows/arc-test-action.yaml
@@ -1,6 +1,7 @@
 name: ARC Test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'test-plan/**'
   push:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   run-crapi-test-plan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     environment: Dev
     timeout-minutes: 20
     runs-on: self-hosted

--- a/.github/workflows/schema-conformance-action.yml
+++ b/.github/workflows/schema-conformance-action.yml
@@ -3,6 +3,7 @@ name: Test Schema Conformance Action
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'schema-conformance/**'
   push:
@@ -18,6 +19,7 @@ permissions:
 
 jobs:
   run-malschema-conformance:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     environment: Dev
     timeout-minutes: 20
     services:

--- a/.github/workflows/test-dast-scan-action.yml
+++ b/.github/workflows/test-dast-scan-action.yml
@@ -8,6 +8,7 @@ permissions:
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'dast-scan/**'
       - '.github/workflows/test-dast-scan-action.yml'
@@ -26,6 +27,7 @@ on:
 
 jobs:
   run-dast-scan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     environment: staging
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/test-plan-action.yml
+++ b/.github/workflows/test-plan-action.yml
@@ -3,6 +3,7 @@ name: Test Plan Action
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'test-plan/**'
   push:
@@ -14,6 +15,7 @@ on:
 
 jobs:
   run-crapi-test-plan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     environment: Dev
     timeout-minutes: 20
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Summary
- Skip all CI workflows on draft PRs to save runner resources.
- Add `ready_for_review` to `pull_request` triggers so workflows fire when a draft is marked as ready.
- Add `if: github.event.pull_request.draft == false` (or the multi-trigger variant) on every job that could fire from a PR event.

## Workflows updated
- `.github/workflows/test-plan-action.yml`
- `.github/workflows/arc-test-action.yaml`
- `.github/workflows/schema-conformance-action.yml`
- `.github/workflows/test-dast-scan-action.yml`

## Test plan
- [ ] Open a draft PR — no workflows run.
- [ ] Push to the draft PR — still skipped.
- [ ] Mark "Ready for review" — workflows trigger.
- [ ] Non-PR triggers still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)