### PR TITLE
fix(scan): add 65-minute step-level timeout backstop

### DIFF
--- a/scan/action.yaml
+++ b/scan/action.yaml
@@ -33,6 +33,11 @@ runs:
   using: 'composite'
   steps:
     - id: run-scan-repo
+      # Hard backstop in case the scanner's own SIGALRM-based timeout (default
+      # 3600s, configurable via LEVO_SCAN_TIMEOUT) fails to terminate atom —
+      # e.g. when atom is wedged in native code that ignores SIGTERM. 65 min =
+      # scanner default (60) + 5 min grace for SIGKILL escalation and cleanup.
+      timeout-minutes: 65
       run: |
         echo "Scanning '${{ inputs.app-name }}' (language: ${{ inputs.language }}, dir: ${{ inputs.dir }}, env: ${{ inputs.env-name }})"
         echo "Using image: ${{ inputs.scanner-docker-image }}"


### PR DESCRIPTION
The Levo code scanner (levoai/code-scanner) has its own SIGALRM-based wall- clock timeout (default 3600s via LEVO_SCAN_TIMEOUT) that terminates a wedged atom subprocess and exits 124. That covers the common case, but signal-based timeouts can fail when the JVM is stuck in native code that ignores SIGTERM — exactly the failure mode that prompted a recent 4h+ hang on a customer's large JS repo.

Adding `timeout-minutes: 65` at the step level (scanner default + 5 min grace for SIGKILL escalation and cleanup) gives GitHub Actions itself a non-bypassable backstop. If the Python timeout works, this never fires. If the Python timeout fails, the job is killed cleanly instead of hanging until the job-level default ceiling.