### PR TITLE
feat(scan): expose --auto-split / --mandatory-scan / --per-folder-timeout inputs

### DIFF
--- a/scan/action.yaml
+++ b/scan/action.yaml
@@ -33,6 +33,18 @@ inputs:
     description: 'Wall-clock limit (seconds) for the analysis phase. If the scan exceeds it, it is aborted with a message to re-run against a smaller `dir`, and the step fails. Mirrors the scanner default of 1 hour. Set to 0 (or negative) to disable.'
     required: false
     default: '3600'
+  auto-split:
+    description: 'When set to "true", runs a serialized per-folder scan instead of analysing the whole repo at once. Useful for very large JS/TS codebases where atom hangs on a single-pass analysis. Each top-level folder is scanned separately and the resulting OpenAPI specs are merged. Defaults to "false".'
+    required: false
+    default: 'false'
+  mandatory-scan:
+    description: 'Comma-separated list of top-level folders that must be scanned even if the whole-folder scan times out — the scanner drills one level deep into each such folder and scans its subfolders separately. Only effective when `auto-split` is "true".'
+    required: false
+    default: ''
+  per-folder-timeout:
+    description: 'Per-folder wall-clock timeout (seconds) when `auto-split` is "true". Defaults to 600 (10 minutes). The outer `scan-timeout` still caps total runtime.'
+    required: false
+    default: '600'
 runs:
   using: 'composite'
   steps:
@@ -43,10 +55,20 @@ runs:
       # quote/escape edge cases and any chance of shell injection.
       env:
         SCAN_TIMEOUT: ${{ inputs.scan-timeout }}
+        AUTO_SPLIT: ${{ inputs.auto-split }}
+        MANDATORY_SCAN: ${{ inputs.mandatory-scan }}
+        PER_FOLDER_TIMEOUT: ${{ inputs.per-folder-timeout }}
       run: |
         echo "Scanning '${{ inputs.app-name }}' (language: ${{ inputs.language }}, dir: ${{ inputs.dir }}, env: ${{ inputs.env-name }})"
         echo "Using image: ${{ inputs.scanner-docker-image }}"
         echo "Scan timeout: ${SCAN_TIMEOUT}s"
+        echo "Auto-split: ${AUTO_SPLIT}"
+        if [ "$AUTO_SPLIT" = "true" ]; then
+          echo "Per-folder timeout: ${PER_FOLDER_TIMEOUT}s"
+          if [ -n "$MANDATORY_SCAN" ]; then
+            echo "Mandatory-scan folders: ${MANDATORY_SCAN}"
+          fi
+        fi
 
         # Per-run unique container name. The previous hardcoded name
         # ("levo-code-scanner") would collide on self-hosted runners with
@@ -76,6 +98,21 @@ runs:
           TIMEOUT_WRAPPER=(timeout --signal=SIGTERM --kill-after=30s "${BACKSTOP_SECONDS}s")
         fi
 
+        # Build the optional auto-split CLI flags so that older scanner images
+        # (which don't know about --auto-split / --mandatory-scan / --per-folder-
+        # timeout) keep working unchanged. The flags are appended only when the
+        # corresponding inputs are set on the action.
+        EXTRA_FLAGS=()
+        if [ "$AUTO_SPLIT" = "true" ]; then
+          EXTRA_FLAGS+=(--auto-split)
+          if [ -n "$PER_FOLDER_TIMEOUT" ] && [ "$PER_FOLDER_TIMEOUT" != "0" ]; then
+            EXTRA_FLAGS+=(--per-folder-timeout "$PER_FOLDER_TIMEOUT")
+          fi
+          if [ -n "$MANDATORY_SCAN" ]; then
+            EXTRA_FLAGS+=(--mandatory-scan "$MANDATORY_SCAN")
+          fi
+        fi
+
         set +e
         # The timeout is passed via the LEVO_SCAN_TIMEOUT env var rather than the
         # --scan-timeout flag: an env var is ignored by older scanner images
@@ -93,7 +130,8 @@ runs:
           --dir "${{ inputs.dir }}" \
           --env-name ${{ inputs.env-name }} \
           -k ${{ inputs.authorization-key }} \
-          -o ${{ inputs.organization-id }} 2>&1)
+          -o ${{ inputs.organization-id }} \
+          "${EXTRA_FLAGS[@]}" 2>&1)
         EXIT_CODE=$?
         echo "$OUTPUT"
 


### PR DESCRIPTION
## Summary

Adds three new inputs to the \`scan\` composite action that drive the per-folder serialized scan path being added to the underlying scanner in [code-scanner PR #31](https://github.com/levoai/code-scanner/pull/31).

## Motivation

A customer with a very large JS/TS monorepo hits atom 2.x's whole-tree slicing hang and runs into our 60-minute scan timeout. The fix on the scanner side is a strictly-additive per-folder code path; this PR is the YAML knob that drives it.

## New inputs

| Input | Default | When honoured |
|---|---|---|
| \`auto-split\` | \`false\` | When \`true\`, the scanner runs the new per-folder serialized scan instead of single-pass. |
| \`mandatory-scan\` | \`''\` (empty) | Comma-separated top-level folder names. Only effective when \`auto-split\` is \`true\`. Such folders get one-level recursive drilling when their whole-folder scan times out. |
| \`per-folder-timeout\` | \`600\` | Per-folder wall-clock budget (seconds) for the serialized path. The existing \`scan-timeout\` still caps total runtime. |

## How the wiring works

The flags are appended to \`docker run\` only when \`auto-split == 'true'\` so:

- **Customers on the new scanner image who don't set \`auto-split\` →** identical behaviour to today. No new flags reach the scanner.
- **Customers using older scanner images (which don't know about the new flags) →** also identical behaviour. The \`EXTRA_FLAGS\` array stays empty unless they actively opt in.
- **Customers who opt in →** see the new behavior.

This is the same shape as the existing \`scan-timeout\` wiring: forward via env var, build flags conditionally, append only if non-default.

## Example YAML using all three inputs

```yaml
- uses: levoai/actions/scan@main
  with:
    authorization-key: \${{ secrets.LEVO_AUTH_KEY }}
    organization-id: \${{ secrets.LEVO_ORG_ID }}
    app-name: Code-Scanner-API
    language: javascript
    env-name: NonProd
    saas-url: https://api.india-1.levo.ai
    auto-split: true
    mandatory-scan: v2,modules
    per-folder-timeout: 600
```

## Per-repo override pattern (for customers using one shared workflow)

For a customer running this workflow across many repos but who only wants auto-split for a specific known-problematic repo:

```yaml
auto-split:     \${{ github.repository == 'Incred-Engineers/Api' && 'true' || 'false' }}
mandatory-scan: \${{ github.repository == 'Incred-Engineers/Api' && 'v2,modules' || '' }}
```

One YAML, deployed everywhere, behaves differently per repo via GitHub Actions expressions.

## Test plan

- [ ] CI: composite action still validates (\`yamllint\` / actionlint).
- [ ] Existing customer workflows without the new inputs still build the same \`docker run\` command (no new flags appended).
- [ ] When \`auto-split: true\` is set, the scanner image (PR #31) receives \`--auto-split\` plus any of the other flags that were provided.

## Companion PR

[\`levoai/code-scanner\` #31](https://github.com/levoai/code-scanner/pull/31) — adds the scanner-side implementation of \`--auto-split\`, \`--mandatory-scan\`, and \`--per-folder-timeout\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)